### PR TITLE
AsyncRecorderPlayerを追加

### DIFF
--- a/Assets/UdpData/Scripts/AsyncRecordPlayer/AsyncRecordPlayer.cs
+++ b/Assets/UdpData/Scripts/AsyncRecordPlayer/AsyncRecordPlayer.cs
@@ -1,13 +1,236 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
+using System.IO;
 using UnityEngine;
 
-public class AsyncRecordPlayer : UdpServer {
+public class AsyncRecordPlayer : UdpServer
+{
+    public UdpSender sender;
+    Queue<TimeDataPair> recordQueue = new Queue<TimeDataPair>();
+    public string recordFilePath = "udpRec.data";
+    public string playFilePath = "recordedUdp/recorded.udp";
+
+    Thread recorder;
+    Thread player;
+    float startTime;
+    public float time;
+
+    public bool recording { get; private set; }
+    public bool playing { get; private set; }
+    public long fileSize { get; private set; }
+    public string exception;
+
+    [Header("field for debug")]
+    public TimeDataPair[] playData;
+
+    private void OnDestroy()
+    {
+        Stop();
+    }
 
     protected override void OnReadPacket(byte[] buffer, int length, IPEndPoint source)
     {
-        //ここでUDPレコードの処理をする
+        if (recording)
+        {
+            var data = new byte[length];
+            System.Buffer.BlockCopy(buffer, 0, data, 0, length);
+            lock (recordQueue)
+            {
+                if (0 < receiveLimit &&  recordQueue.Count < receiveLimit)
+                    recordQueue.Enqueue(new TimeDataPair() { time = GetCurrentTime() - startTime, data = data });
+            }
+        }
     }
 
+    public void CreatePlayData()
+    {
+        var list = new List<TimeDataPair>();
+        if (File.Exists(playFilePath))
+        {
+            var fileData = File.ReadAllBytes(playFilePath);
+            using (var stream = new MemoryStream(fileData))
+            using (var reader = new BinaryReader(stream))
+            {
+                var enl = false;
+                while (!enl)
+                {
+                    try
+                    {
+                        var time = reader.ReadSingle();
+                        var count = reader.ReadInt32();
+                        var data = reader.ReadBytes(count);
+                        list.Add(new TimeDataPair() { time = time, data = data });
+                    }
+                    catch (EndOfStreamException)
+                    {
+                        enl = true;
+                    }
+                }
+            }
+            playData = list.ToArray();
+        }
+    }
+
+    [ContextMenu("Start Recording")]
+    public void StartRecording()
+    {
+        recording = true;
+        startTime = GetCurrentTime();
+        recordQueue.Clear();
+
+        if (recorder != null)
+            recorder.Abort();
+        recorder = new Thread(RecordLoop);
+        recorder.Start();
+    }
+
+    [ContextMenu("Play RecordedData")]
+    public void Play()
+    {
+        playing = true;
+        startTime = GetCurrentTime();
+        time = 0;
+
+        if (player != null)
+            player.Abort();
+        player = new Thread(PlayLoop);
+        player.Start();
+    }
+
+    [ContextMenu("Stop Rec-Play")]
+    public void Stop()
+    {
+        recording = false;
+        playing = false;
+        if (recorder != null)
+            recorder.Abort();
+        recorder = null;
+        if (player != null)
+            player.Abort();
+        player = null;
+    }
+
+    public void Play(string filePath, float playStartTime)
+    {
+        if (playing)
+            Stop();
+        playing = true;
+        startTime = GetCurrentTime() - playStartTime;
+        time = playStartTime;
+
+        playFilePath = filePath;
+        if (!File.Exists(filePath))
+            return;
+
+        if (player != null)
+            player.Abort();
+        player = new Thread(PlayLoop);
+        player.Start();
+    }
+
+    private void Update()
+    {
+        if (playing || recording)
+            time = GetCurrentTime() - startTime;
+    }
+
+    void RecordLoop()
+    {
+        using (var stream = new FileStream(recordFilePath, FileMode.Create))
+        using (var writer = new BinaryWriter(stream))
+        {
+            while (recording)
+                try
+                {
+                    lock (recordQueue)
+                    {
+                        if (0 < recordQueue.Count)
+                        {
+                            var pair = recordQueue.Dequeue();
+                            if (pair.data != null)
+                            {
+                                writer.Write(pair.time);
+                                writer.Write(pair.data.Length);
+                                writer.Write(pair.data);
+                                fileSize = stream.Length;
+                            }
+                        }
+                    }
+                }
+                catch (System.Exception e)
+                {
+                    exception = e.ToString();
+                }
+
+            writer.Close();
+            stream.Close();
+        }
+    }
+
+    void PlayLoop()
+    {
+        var recordedData = File.ReadAllBytes(playFilePath);
+        using (var stream = new MemoryStream(recordedData))
+        using (var reader = new BinaryReader(stream))
+        {
+            fileSize = stream.Length;
+            var startTime = time;
+            while (playing)
+            {
+                try
+                {
+                    var nextTime = reader.ReadSingle();
+                    var count = reader.ReadInt32();
+                    while(nextTime < startTime) {
+                        reader.ReadBytes(count);
+                        nextTime = reader.ReadSingle();
+                        count = reader.ReadInt32();
+                    }
+
+
+                    if (0 < count)
+                    {
+                        var data = reader.ReadBytes(count);
+                        {
+                            while (time < nextTime && playing)
+                            {
+
+                            }
+                            sender.Send(data);
+                        }
+                    }
+                    else
+                        playing = false;
+                }
+                catch (EndOfStreamException)
+                {
+                    playing = false;
+                    reader.Close();
+                    stream.Close();
+                    return;
+                }
+                catch (System.Exception e)
+                {
+                    exception = e.ToString();
+                }
+            }
+            reader.Close();
+            stream.Close();
+        }
+    }
+
+    static float GetCurrentTime()
+    {
+        return (float)Environment.TickCount / 1000.0f;
+    }
+
+    [System.Serializable]
+    public struct TimeDataPair
+    {
+        public float time;
+        public byte[] data;
+    }
 }

--- a/Assets/UdpData/Scripts/AsyncRecordPlayer/AsyncRecorderApp.cs
+++ b/Assets/UdpData/Scripts/AsyncRecordPlayer/AsyncRecorderApp.cs
@@ -1,0 +1,218 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using UnityEngine;
+using FileUtility;
+
+[RequireComponent(typeof(AsyncRecordPlayer))]
+public class AsyncRecorderApp : MonoBehaviour
+{
+
+    public int windowWidth = 768;
+    public int windowHeight = 480;
+    Rect windowRect;
+
+    string fileName = "data";
+    const string fileExtension = ".udp";
+    AsyncRecordPlayer recorder;
+
+    string error = "";
+
+    string remoteIp;
+    int remotePort;
+    int localPort;
+
+    public UdpSender sender;
+    public UdpServer server;
+
+    string parentFolder;
+    bool hide;
+    #region cll methods via osc
+    public void RecStartOsc(object[] data)
+    {
+        var filePath = Path.Combine(parentFolder, fileName + fileExtension);
+        if (!File.Exists(filePath))
+            recorder.StartRecording();
+    }
+
+    public void PlayStartOsc(object[] data)
+    {
+        fileName = (string)data[0];
+        var startTime = (float)data[1];
+        var filePath = Path.Combine(parentFolder, fileName + fileExtension);
+        if (File.Exists(filePath))
+            recorder.Play(filePath, startTime);
+    }
+
+    public void StopOsc(object[] data)
+    {
+        recorder.Stop();
+    }
+    #endregion
+
+    public void OnError(System.Exception e)
+    {
+        error = e.ToString();
+    }
+
+    // Use this for initialization
+    void Start()
+    {
+        remoteIp = sender.remoteIp;
+        remotePort = sender.remotePort;
+        localPort = server.localPort;
+
+        var x = Screen.width / 2f - windowWidth / 2f;
+        var y = Screen.height / 2f - windowHeight / 2f;
+        windowRect = new Rect(new Vector2(x, y), new Vector2(windowWidth, windowHeight));
+
+        recorder = GetComponent<AsyncRecordPlayer>();
+
+        parentFolder = Path.Combine(Application.streamingAssetsPath, "udpData");
+        if (!Directory.Exists(parentFolder))
+            Directory.CreateDirectory(parentFolder);
+    }
+
+
+    private void OnGUI()
+    {
+        windowRect = GUI.Window(GetInstanceID(), windowRect, OnGUIWindow, "UDP Recorder");
+    }
+
+    void OnGUIWindow(int id)
+    {
+        if (hide = GUILayout.Toggle(hide, "Hide GUI"))
+            return;
+
+        GUILayout.Space(4);
+
+        GUILayout.Label("FolderPath:");
+        if (GUILayout.Button(parentFolder))
+            OpenInFileBrowser.Open(parentFolder);
+
+        GUILayout.BeginHorizontal();
+        GUILayout.Label("FileName: ");
+        fileName = GUILayout.TextField(fileName, GUILayout.Width(320));
+        GUILayout.Label(fileExtension);
+        GUILayout.EndHorizontal();
+
+        GUILayout.Space(16);
+
+        var filePath = Path.Combine(parentFolder, fileName + fileExtension);
+        var exist = File.Exists(filePath);
+
+        if (exist && !recorder.playing && !recorder.recording)
+        {
+            recorder.playFilePath = filePath;
+            GUILayout.BeginHorizontal();
+            if (GUILayout.Button("/play"))
+                recorder.Play();
+            if (GUILayout.Button("create playData"))
+                recorder.CreatePlayData();
+            GUILayout.EndHorizontal();
+        }
+        else if (!exist && !recorder.recording)
+        {
+            recorder.recordFilePath = filePath;
+            if (GUILayout.Button("/record"))
+                recorder.StartRecording();
+        }
+
+        if ((recorder.playing || recorder.recording))
+        {
+            if (GUILayout.Button("/stop"))
+            {
+                if (recorder.recording)
+                {
+                    var array = fileName.Split('_');
+                    var num = 0;
+                    if (0 < array.Length && int.TryParse(array.Last(), out num))
+                    {
+                        array[array.Length - 1] = (num + 1).ToString();
+                        fileName = string.Join("_", array);
+                    }
+                    else
+                        fileName += "_0";
+                }
+                recorder.Stop();
+            }
+        }
+        else
+        {
+            GUILayout.Space(16);
+            GUILayout.BeginVertical("box");
+            if (SetIpField("Remote IP: ", ref remoteIp) || SetPortField("Remote Port", ref remotePort))
+                sender.CreateRemoteEP(remoteIp, remotePort);
+            GUILayout.Space(8);
+            if (SetPortField("Local Port: ", ref localPort))
+                server.StartServer(localPort);
+            GUILayout.EndVertical();
+        }
+
+        if (0 < error.Length)
+        {
+            var color = GUI.color;
+            GUI.color = Color.red;
+            GUILayout.Label(error);
+            GUI.color = color;
+        }
+
+        GUILayout.Space(16);
+        if (recorder.playing || recorder.recording)
+        {
+            var fileSize = (float)recorder.fileSize;
+            var unit = "B";
+            if (1024 < fileSize)
+            {
+                fileSize /= 1024;
+                unit = "KB";
+            }
+            if (1024 < fileSize)
+            {
+                fileSize /= 1024;
+                unit = "MB";
+            }
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(recorder.playing ? "playing: " : "recording: ");
+            GUILayout.Label(recorder.time.ToString(), GUILayout.Width(200));
+            GUILayout.FlexibleSpace();
+            GUILayout.Label("file size: ");
+            GUILayout.Label(fileSize.ToString(".000") + unit);
+            GUILayout.EndHorizontal();
+        }
+
+        GUI.DragWindow();
+    }
+
+    bool SetIpField(string label, ref string ip)
+    {
+        GUILayout.BeginHorizontal();
+        GUILayout.Label(label);
+        var str = GUILayout.TextField(ip);
+        GUILayout.EndHorizontal();
+
+        if (str == ip)
+            return false;
+        ip = str;
+        return true;
+    }
+    bool SetPortField(string label, ref int port)
+    {
+        GUILayout.BeginHorizontal();
+        GUILayout.Label(label);
+        var str = GUILayout.TextField(port.ToString());
+        GUILayout.EndHorizontal();
+
+        int i;
+        if (int.TryParse(str, out i))
+            if (i != port)
+            {
+                port = i;
+                return true;
+            }
+
+        return false;
+    }
+}

--- a/Assets/UdpData/Scripts/AsyncRecordPlayer/AsyncRecorderApp.cs.meta
+++ b/Assets/UdpData/Scripts/AsyncRecordPlayer/AsyncRecorderApp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0325629487aaee942860f3fddbb6fa19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UdpData/asyncRecorder.unity
+++ b/Assets/UdpData/asyncRecorder.unity
@@ -1,0 +1,351 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 10
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ShowResolutionOverlay: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &17652618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 17652619}
+  - component: {fileID: 17652621}
+  - component: {fileID: 17652620}
+  - component: {fileID: 17652622}
+  m_Layer: 0
+  m_Name: AsyncRecordePlayerApp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &17652619
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 17652618}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &17652620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 17652618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0325629487aaee942860f3fddbb6fa19, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  windowWidth: 768
+  windowHeight: 480
+  sender: {fileID: 17652622}
+  server: {fileID: 17652621}
+--- !u!114 &17652621
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 17652618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 49453cfa907048042922af62eb268edf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  localPort: 6666
+  receiveLimit: 10
+  errorMsg: 
+  sender: {fileID: 17652622}
+  recordFilePath: udpRec.data
+  playFilePath: recordedUdp/recorded.udp
+  time: 0
+  exception: 
+  playData: []
+--- !u!114 &17652622
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 17652618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 69163ce0f4a448a48915142d54c5552a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sendTextData: test
+  remoteIp: localhost
+  useBroadCast: 0
+  remotePort: 6454
+--- !u!1 &292776869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 292776872}
+  - component: {fileID: 292776871}
+  - component: {fileID: 292776870}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &292776870
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292776869}
+  m_Enabled: 1
+--- !u!20 &292776871
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292776869}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &292776872
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292776869}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1202745513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1202745515}
+  - component: {fileID: 1202745514}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1202745514
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1202745513}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1202745515
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1202745513}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}

--- a/Assets/UdpData/asyncRecorder.unity.meta
+++ b/Assets/UdpData/asyncRecorder.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f95b57c8856682b4e8af0a998acb00dc
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
主な変更点
- RawDataServerとUdpRecordPlayerを統合したAsyncRecordPlayerを追加
- UnityのTimeの代わりにSystem.Environment.TickCountを使用するように変更
- キューのデータを1つずつ書き込むように変更

追加でキューのデータの書き込みを1つずつ行うように変更しました
もし書き込み速度がUDPの読み取り速度に追いついていなかった場合キューが常に最大サイズになってしまい時系列にデータの塊が点在してしまうと思います
一つずつ書き込むことによって時系列に安定してデータが存在するようになるかと…！

Pythonで大量のOSC送るテストはしてみたのですが30fpsぐらいしか出せなかったので実際の許容量に耐えうるかは不安です
あとUnityのバージョン 2018.3.0f2で作成したのでもしかすると何か差分が出るかもしれません

よろしくおねがいします！
